### PR TITLE
feat: keep_lowercase_reference flag

### DIFF
--- a/src/base/structs_and_traits.rs
+++ b/src/base/structs_and_traits.rs
@@ -70,6 +70,7 @@ pub struct FilterStats {
     pub remove_ns: bool,
     pub remove_monoallelic: bool,
     pub keep_if_any_meets_coverage: bool,
+    pub keep_lowercase_reference: bool,
     pub max_base_error_rate: f64,
     pub min_coverage: u64,
     pub min_allele_frequency: f64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,9 @@ struct Args {
     /// Maximum missingness rate (loci with missing data beyond this threshold will be omitted)
     #[clap(long, default_value_t = 0.0)]
     max_missingness_rate: f64,
+    /// Categorize lowercase reference reads in pileup as unclassified ('N')
+    #[clap(long, action)]
+    keep_lowercase_reference: bool,
     /// Keep ambiguous reads during SNP filtering, i.e. keep them coded as Ns
     #[clap(long, action)]
     keep_ns: bool,
@@ -194,6 +197,7 @@ fn main() {
         remove_ns: !args.keep_ns,
         remove_monoallelic: args.remove_monoallelic,
         keep_if_any_meets_coverage: args.keep_if_any_meets_coverage,
+        keep_lowercase_reference: args.keep_lowercase_reference,
         max_base_error_rate: args.max_base_error_rate,
         min_coverage: args.min_coverage,
         min_allele_frequency: args.min_allele_frequency,


### PR DESCRIPTION
Flag to toggle whether lowercase reference bases are kept as they are or converted to be unclassified ('N')

closes #19 