### PR TITLE
feat: min_coverage_breadth

### DIFF
--- a/src/base/filter_stats.rs
+++ b/src/base/filter_stats.rs
@@ -1,0 +1,57 @@
+use std::io::{self, Error, ErrorKind};
+
+use crate::base::*;
+
+impl Parse<FilterStats> for FilterStats {
+    fn lparse(&self) -> io::Result<Box<FilterStats>> {
+        let remove_ns = self.remove_ns.clone();
+        let remove_monoallelic = self.remove_monoallelic.clone();
+        let keep_lowercase_reference = self.keep_lowercase_reference.clone();
+        let max_base_error_rate = if self.max_base_error_rate <= 1.0 && self.max_base_error_rate >= 0.0 {
+            self.max_base_error_rate.clone()
+        } else {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Invalid range. max_base_error_rate must be between 0.0 and 1.0",
+            ));
+        };
+        let min_coverage_depth = self.min_coverage_depth.clone();
+        let min_coverage_breadth = if self.min_coverage_breadth <= 1.0 && self.max_base_error_rate >= 0.0 {
+            self.min_coverage_breadth.clone()
+        } else {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Invalid range. min_coverage_breadth must be between 0.0 and 1.0",
+            ));
+        };
+        let min_allele_frequency = if self.min_allele_frequency <= 1.0 && self.min_allele_frequency >= 0.0 {
+            self.min_allele_frequency.clone()
+        } else {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Invalid range. min_allele_frequency must be between 0.0 and 1.0",
+            ));
+        };
+        let max_missingness_rate = if self.max_missingness_rate <= 1.0 && self.max_missingness_rate >= 0.0 {
+            self.max_missingness_rate.clone()
+        } else {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Invalid range. max_missingness_rate must be between 0.0 and 1.0",
+            ));
+        };
+        let pool_sizes = self.pool_sizes.clone();
+
+        return Ok(Box::new(FilterStats {
+            remove_ns,
+            remove_monoallelic,
+            keep_lowercase_reference,
+            max_base_error_rate,
+            min_coverage_depth,
+            min_coverage_breadth,
+            min_allele_frequency,
+            max_missingness_rate,
+            pool_sizes,
+        }));
+    }
+}

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -6,3 +6,4 @@ mod pileup;
 mod structs_and_traits;
 mod sync;
 mod vcf;
+mod filter_stats;

--- a/src/base/structs_and_traits.rs
+++ b/src/base/structs_and_traits.rs
@@ -69,10 +69,10 @@ pub struct FileSyncPhen {
 pub struct FilterStats {
     pub remove_ns: bool,
     pub remove_monoallelic: bool,
-    pub keep_if_any_meets_coverage: bool,
     pub keep_lowercase_reference: bool,
     pub max_base_error_rate: f64,
-    pub min_coverage: u64,
+    pub min_coverage_depth: u64,
+    pub min_coverage_breadth: f64,
     pub min_allele_frequency: f64,
     pub max_missingness_rate: f64,
     pub pool_sizes: Vec<f64>,

--- a/src/base/sync.rs
+++ b/src/base/sync.rs
@@ -224,12 +224,12 @@ impl Filter for LocusCounts {
             sum_coverage
                 .iter()
                 .fold(sum_coverage[0], |min, &x| if x < min { x } else { min });
-        if min_sum_coverage < filter_stats.min_coverage as f64 {
+        if min_sum_coverage < filter_stats.min_coverage_depth as f64 {
             return Err(Error::new(ErrorKind::Other, "Filtered out."));
         }
         // // TODO: convert loci failing the minimum coverage threshold into missing instead of omitting the entire locus
         // for i in 0..self.matrix.nrows() {
-        //     if sum_coverage[i] < filter_stats.min_coverage as f64 {
+        //     if sum_coverage[i] < filter_stats.min_coverage_depth as f64 {
         //         for j in 0..self.matrix.ncols() {
         //             self.matrix[(i, j)] = f64::NAN as u64;
         //         }
@@ -1569,8 +1569,11 @@ mod tests {
         let frequencies = *(counts.to_frequencies().unwrap());
         let filter_stats = FilterStats {
             remove_ns: true,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.005,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0, 
             min_allele_frequency: 0.005,
             max_missingness_rate: 0.0,
             pool_sizes: vec![20., 20., 20., 20., 20.],
@@ -1675,8 +1678,11 @@ mod tests {
         // let phen = file_phen.lparse().unwrap();
         // let filter_stats = FilterStats {
         //     remove_ns: true,
+        //     remove_monoallelic: false,
+        //     keep_lowercase_reference: false,
         //     max_base_error_rate: 0.005,
-        //     min_coverage: 0,
+        //     min_coverage_depth: 0,
+        //     min_coverage_breadth: 1.0,
         //     min_allele_frequency: 0.0001,
         //     max_missingness_rate: 0.2,
         //     pool_sizes: phen.pool_sizes,

--- a/src/gp/cv.rs
+++ b/src/gp/cv.rs
@@ -444,8 +444,11 @@ mod tests {
         let n_threads = 2;
         let filter_stats = FilterStats {
             remove_ns: true,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.005,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.005,
             max_missingness_rate: 0.0,
             pool_sizes: vec![0.2, 0.2, 0.2, 0.2, 0.2],

--- a/src/gwas/correlation_test.rs
+++ b/src/gwas/correlation_test.rs
@@ -148,8 +148,11 @@ mod tests {
             Array2::from_shape_vec((5, 2), vec![1, 9, 2, 8, 3, 7, 4, 6, 5, 5]).unwrap();
         let filter_stats = FilterStats {
             remove_ns: true,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.005,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.005,
             max_missingness_rate: 0.0,
             pool_sizes: vec![20.0, 20.0, 20.0, 20.0, 20.0],

--- a/src/gwas/gwalpha.rs
+++ b/src/gwas/gwalpha.rs
@@ -416,8 +416,11 @@ mod tests {
         .reversed_axes();
         let filter_stats = FilterStats {
             remove_ns: true,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.005,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.005,
             max_missingness_rate: 0.0,
             pool_sizes: vec![20.0, 20.0, 20.0, 20.0, 20.0],

--- a/src/gwas/ols.rs
+++ b/src/gwas/ols.rs
@@ -549,7 +549,7 @@ mod tests {
         // let filter_stats = FilterStats {
         //     remove_ns: true,
         //     max_base_error_rate: 0.005,
-        //     min_coverage: 1,
+        //     min_coverage_depth: 1,
         //     min_allele_frequency: 0.005,
         //     pool_sizes: vec![20.0, 20.0, 20.0, 20.0, 20.0],
         // };

--- a/src/imputation/adaptive_ld_knn_imputation.rs
+++ b/src/imputation/adaptive_ld_knn_imputation.rs
@@ -497,8 +497,11 @@ mod tests {
         let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
         let filter_stats = FilterStats {
             remove_ns: true,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.005,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.005,
             max_missingness_rate: 0.0,
             pool_sizes: vec![20., 20., 20., 20., 20.],

--- a/src/imputation/filtering_missing.rs
+++ b/src/imputation/filtering_missing.rs
@@ -255,8 +255,11 @@ mod tests {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////
         let filter_stats = FilterStats {
             remove_ns: false,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 1.0,
-            min_coverage: 0,
+            min_coverage_depth: 0,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.000001,
             max_missingness_rate: 0.0,
             pool_sizes: vec![20., 20., 20., 20., 20.],

--- a/src/imputation/mean_imputation.rs
+++ b/src/imputation/mean_imputation.rs
@@ -182,8 +182,11 @@ mod tests {
         let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
         let filter_stats = FilterStats {
             remove_ns: true,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.005,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.005,
             max_missingness_rate: 0.0,
             pool_sizes: vec![20., 20., 20., 20., 20.],

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ fn main() {
         format: phen_format,
     };
     let phen = file_phen.lparse().unwrap();
-    let filter_stats = base::FilterStats {
+    let file_filter_stats = base::FilterStats {
         remove_ns: !args.keep_ns,
         remove_monoallelic: args.remove_monoallelic,
         keep_lowercase_reference: args.keep_lowercase_reference,
@@ -204,6 +204,7 @@ fn main() {
         max_missingness_rate: args.max_missingness_rate,
         pool_sizes: phen.pool_sizes.clone(),
     };
+    let filter_stats = file_filter_stats.lparse().unwrap();
     if args.analysis == String::from("pileup2sync") {
         // PILEUP INPUT
         let file_pileup = base::FilePileup {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,12 @@ struct Args {
     /// Maximum base sequencing error rate
     #[clap(long, default_value_t = 0.01)]
     max_base_error_rate: f64,
-    /// Minimum depth of coverage (loci with at least one pool below this threshold will be omitted)
+    /// Minimum breadth of coverage (loci with less than this proportion of pools below min_coverage_depth will be omitted)
+    #[clap(long, default_value_t = 1.0)]
+    min_coverage_breadth: f64,
+    /// Minimum depth of coverage (loci with less than min_coverage_breadth pools below this threshold will be omitted)
     #[clap(long, default_value_t = 1)]
-    min_coverage: u64,
+    min_coverage_depth: u64,
     /// Minimum allele frequency (per locus, alleles which fail to pass this threshold will be omitted allowing control over multiallelic loci)
     #[clap(long, default_value_t = 0.001)]
     min_allele_frequency: f64,
@@ -55,9 +58,6 @@ struct Args {
     /// Keep ambiguous reads during SNP filtering, i.e. keep them coded as Ns
     #[clap(long, action)]
     keep_ns: bool,
-    /// Keep loci if any population meets min_coverage, verses only keeping if ALL loci meet coverage (default)
-    #[clap(long, action)]
-    keep_if_any_meets_coverage: bool,
     /// Remove monoallelic loci (each loci must have coverage of at least 2 alleles)
     #[clap(long, action)]
     remove_monoallelic: bool,
@@ -196,10 +196,10 @@ fn main() {
     let filter_stats = base::FilterStats {
         remove_ns: !args.keep_ns,
         remove_monoallelic: args.remove_monoallelic,
-        keep_if_any_meets_coverage: args.keep_if_any_meets_coverage,
         keep_lowercase_reference: args.keep_lowercase_reference,
         max_base_error_rate: args.max_base_error_rate,
-        min_coverage: args.min_coverage,
+        min_coverage_breadth: args.min_coverage_breadth,
+        min_coverage_depth: args.min_coverage_depth,
         min_allele_frequency: args.min_allele_frequency,
         max_missingness_rate: args.max_missingness_rate,
         pool_sizes: phen.pool_sizes.clone(),

--- a/src/popgen/gudmc.rs
+++ b/src/popgen/gudmc.rs
@@ -484,8 +484,11 @@ mod tests {
         let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
         let filter_stats = FilterStats {
             remove_ns: false,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.01,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.001,
             max_missingness_rate: 0.0,
             pool_sizes: vec![42.0, 42.0, 42.0, 42.0, 42.0],

--- a/src/tables/chisq_test.rs
+++ b/src/tables/chisq_test.rs
@@ -67,8 +67,11 @@ mod tests {
         };
         let filter_stats = FilterStats {
             remove_ns: true,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.01,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.005,
             max_missingness_rate: 0.0,
             pool_sizes: vec![0.2, 0.2, 0.2, 0.2],

--- a/src/tables/fisher_exact_test.rs
+++ b/src/tables/fisher_exact_test.rs
@@ -148,8 +148,11 @@ mod tests {
             Array2::from_shape_vec((3, 2), vec![0, 3, 1, 5, 2, 6]).unwrap();
         let filter_stats = FilterStats {
             remove_ns: true,
+            remove_monoallelic: false,
+            keep_lowercase_reference: false,
             max_base_error_rate: 0.005,
-            min_coverage: 1,
+            min_coverage_depth: 1,
+            min_coverage_breadth: 1.0,
             min_allele_frequency: 0.005,
             max_missingness_rate: 0.0,
             pool_sizes: vec![0.2, 0.2, 0.2],


### PR DESCRIPTION
fix: outdated tests

replaced keep_if_any_meets_coverage with min_coverage_breadth, which allows specifying frequency of pools that need to meet coverage requirement. (renamed min_coverage to min_coverage_depth for clarity)

made tests up to date with new flags