### PR TITLE
Extract potentially significant annotations from .gff file

### DIFF
--- a/src/base/helpers.rs
+++ b/src/base/helpers.rs
@@ -33,41 +33,25 @@ pub fn run_python_and_append(output: &str, script_names: &[&str]) -> String {
 
     let outputs: Vec<String> = std::iter::once(output.to_string())
         .chain(script_names.iter().map(|script_name| {
-            let abs_script = fs::canonicalize(scripts_dir.join(script_name))
-                .unwrap_or_else(|_| panic!("Failed to find script {}", script_name));
+            let result: Result<String, Box<dyn std::error::Error>> = (|| {
+                let abs_script = fs::canonicalize(scripts_dir.join(script_name))?;
+                let output = Command::new("python3")
+                    .arg(&abs_script)
+                    .arg(&abs_output)
+                    .output()?;
 
-            let output = Command::new("python3")
-                .arg(&abs_script)
-                .arg(&abs_output)
-                .output()
-                .unwrap_or_else(|_| panic!("Failed to run {}", script_name));
+                if !output.status.success() {
+                    return Err(format!("WARNING: {} failed: {}", script_name, String::from_utf8_lossy(&output.stderr)).into());
+                }
 
-            if !output.status.success() { panic!( "{} failed:\n{}", script_name, String::from_utf8_lossy(&output.stderr)) }
+                Ok(String::from_utf8_lossy(&output.stdout).to_string())
+            })();
 
-            String::from_utf8_lossy(&output.stdout).to_string()
+            result.unwrap_or_else(|e| e.to_string())
         }))
         .collect();
 
     outputs.join("\n")
-}
-
-/// Run general python script
-pub fn run_python(output: &str, script_names: &[&str]) {
-    let abs_output = fs::canonicalize(output).expect("Failed to canonicalize output path");
-    let scripts_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/python");
-
-    for script_name in script_names {
-        let abs_script = fs::canonicalize(scripts_dir.join(script_name))
-            .unwrap_or_else(|_| panic!("Failed to find script {}", script_name));
-
-        let output = Command::new("python3")
-            .arg(&abs_script)
-            .arg(&abs_output)
-            .output()
-            .unwrap_or_else(|_| panic!("Failed to run {}", script_name));
-
-        if !output.status.success() { panic!( "{} failed:\n{}", script_name, String::from_utf8_lossy(&output.stderr)) }
-    }
 }
 
 /// Detect the cursor positions across the input file corresponding to the splits for parallel computation

--- a/src/base/pileup.rs
+++ b/src/base/pileup.rs
@@ -332,7 +332,7 @@ impl Filter for PileupLine {
 /// Convert `PileupLine` into a string representing a line or locus in a `sync` file.
 pub fn pileup_to_sync(pileup_line: &mut PileupLine, filter_stats: &FilterStats) -> Option<String> {
     // First, make sure we have the correct number of expected pools as the phenotype file
-    assert!(pileup_line.coverages.len() != filter_stats.pool_sizes.len(), "The number of pools in the pileup file does not correspond to the number of pools in the phenotype file.");
+    assert!(pileup_line.coverages.len() == filter_stats.pool_sizes.len(), "The number of pools in the pileup file does not correspond to the number of pools in the phenotype file.");
     // Filter
     match pileup_line.filter(filter_stats) {
         Ok(Some(x)) => x,

--- a/src/base/pileup.rs
+++ b/src/base/pileup.rs
@@ -238,11 +238,6 @@ impl Filter for PileupLine {
     /// - removing the entire locus if the locus is fixed, i.e. only 1 allele was found or retained after filterings
     /// Note that we are not removing alleles per locus if they fail the minimum allele frequency threshold, only if all alleles fail this threshold, i.e. when the locus is close to being fixed
     fn filter(&mut self, filter_stats: &FilterStats) -> io::Result<Option<&mut Self>> {
-        // First, make sure we have the correct number of expected pools as the phenotype file
-        // TODO: Make the error pop-out because it's currently being consumed as None in the only function calling it below.
-        if self.coverages.len() != filter_stats.pool_sizes.len() {
-            return Err(Error::new(ErrorKind::Other, "The number of pools in the pileup file does not correspond to the number of pools in the phenotype file."));
-        }
         // Convert low quality bases into Ns
         let n = self.read_qualities.len();
         for i in 0..n {
@@ -336,7 +331,8 @@ impl Filter for PileupLine {
 
 /// Convert `PileupLine` into a string representing a line or locus in a `sync` file.
 pub fn pileup_to_sync(pileup_line: &mut PileupLine, filter_stats: &FilterStats) -> Option<String> {
-    // let mut pileup_line: Box<PileupLine> = line.lparse().unwrap();
+    // First, make sure we have the correct number of expected pools as the phenotype file
+    assert!(pileup_line.coverages.len() != filter_stats.pool_sizes.len(), "The number of pools in the pileup file does not correspond to the number of pools in the phenotype file.");
     // Filter
     match pileup_line.filter(filter_stats) {
         Ok(Some(x)) => x,
@@ -659,3 +655,4 @@ mod tests {
         );
     }
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,12 +270,12 @@ fn main() {
                     gwas::ols_iterate,
                 )
                 .unwrap();
-            let original_output = output.clone();
-            if args.generate_plots {
-                output = base::run_python_and_append(&original_output, &["plot_manhattan.py", "plot_qq.py"])
-            }
-            if args.output_sig_snps_only {
-                base::run_python(&original_output, &["remove_insig_snps.py"])
+            let python_scripts: Vec<&str> = [
+                args.generate_plots.then_some(["plot_manhattan.py", "plot_qq.py"].as_slice()).unwrap_or(&[]),
+                args.output_sig_snps_only.then_some(["remove_insig_snps.py"].as_slice()).unwrap_or(&[])
+            ].concat();
+            if !python_scripts.is_empty() {
+                output = base::run_python_and_append(&output.clone(), &python_scripts);
             }
         } else if args.analysis == String::from("ols_iter_with_kinship") {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
@@ -289,12 +289,12 @@ fn main() {
                 &args.output,
             )
             .unwrap();
-            let original_output = output.clone();
-            if args.generate_plots {
-                output = base::run_python_and_append(&original_output, &["plot_manhattan.py", "plot_qq.py"])
-            }
-            if args.output_sig_snps_only {
-                base::run_python(&original_output, &["remove_insig_snps.py"])
+            let python_scripts: Vec<&str> = [
+                args.generate_plots.then_some(["plot_manhattan.py", "plot_qq.py"].as_slice()).unwrap_or(&[]),
+                args.output_sig_snps_only.then_some(["remove_insig_snps.py"].as_slice()).unwrap_or(&[])
+            ].concat();
+            if !python_scripts.is_empty() {
+                output = base::run_python_and_append(&output.clone(), &python_scripts);
             }
         } else if args.analysis == String::from("mle_iter") {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
@@ -306,12 +306,12 @@ fn main() {
                     gwas::mle_iterate,
                 )
                 .unwrap();
-            let original_output = output.clone();
-            if args.generate_plots {
-                output = base::run_python_and_append(&original_output, &["plot_manhattan.py", "plot_qq.py"])
-            }
-            if args.output_sig_snps_only {
-                base::run_python(&original_output, &["remove_insig_snps.py"])
+            let python_scripts: Vec<&str> = [
+                args.generate_plots.then_some(["plot_manhattan.py", "plot_qq.py"].as_slice()).unwrap_or(&[]),
+                args.output_sig_snps_only.then_some(["remove_insig_snps.py"].as_slice()).unwrap_or(&[])
+            ].concat();
+            if !python_scripts.is_empty() {
+                output = base::run_python_and_append(&output.clone(), &python_scripts);
             }
         } else if args.analysis == String::from("mle_iter_with_kinship") {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
@@ -325,12 +325,12 @@ fn main() {
                 &args.output,
             )
             .unwrap();
-            let original_output = output.clone();
-            if args.generate_plots {
-                output = base::run_python_and_append(&original_output, &["plot_manhattan.py", "plot_qq.py"])
-            }
-            if args.output_sig_snps_only {
-                base::run_python(&original_output, &["remove_insig_snps.py"])
+            let python_scripts: Vec<&str> = [
+                args.generate_plots.then_some(["plot_manhattan.py", "plot_qq.py"].as_slice()).unwrap_or(&[]),
+                args.output_sig_snps_only.then_some(["remove_insig_snps.py"].as_slice()).unwrap_or(&[])
+            ].concat();
+            if !python_scripts.is_empty() {
+                output = base::run_python_and_append(&output.clone(), &python_scripts);
             }
         } else if args.analysis == String::from("gwalpha") {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
@@ -506,3 +506,4 @@ fn main() {
     }
     println!("{}", output);
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,10 +182,10 @@ struct Args {
 fn main() {
     env::set_var("RUST_BACKTRACE", "1");
     let args = Args::parse();
-    let mut output: String = String::from("");
+    let mut output = String::new();
     // Prepare the mandatory inputs
     let mut phen_format = "default".to_string();
-    if args.analysis == String::from("gwalpha") {
+    if args.analysis == "gwalpha" {
         phen_format = "gwalpha_fmt".to_string()
     }
     let phen_col = args
@@ -215,198 +215,134 @@ fn main() {
         max_missingness_rate: args.max_missingness_rate,
         pool_sizes: phen.pool_sizes.clone(),
     };
-    if args.analysis == String::from("pileup2sync") {
+    if args.analysis == "pileup2sync" {
         // PILEUP INPUT
         let file_pileup = base::FilePileup {
             filename: args.fname,
             pool_names: phen.pool_names,
         };
-        output = file_pileup
+        output = format!("FILE CREATED: {}", file_pileup
             .read_analyse_write(
                 &filter_stats,
                 &args.output,
                 &args.n_threads,
                 base::pileup_to_sync,
             )
-            .unwrap();
-    } else if args.analysis == String::from("vcf2sync") {
+            .unwrap());
+    } else if args.analysis == "vcf2sync" {
         // VCF INPUT
         let file_vcf = base::FileVcf {
             filename: args.fname,
         };
-        output = file_vcf
+        output = format!("FILE CREATED: {}", file_vcf
             .read_analyse_write(
                 &filter_stats,
                 &args.output,
                 &args.n_threads,
                 base::vcf_to_sync,
             )
-            .unwrap();
+            .unwrap());
     } else {
         // SYNC INPUT
         let file_sync = base::FileSync {
             filename: args.fname.clone(),
             test: args.analysis.clone(),
         };
-        if args.analysis == String::from("fisher_exact_test") {
-            output = file_sync
+        if args.analysis == "fisher_exact_test" {
+            output = format!("FILE CREATED: {}", file_sync
                 .read_analyse_write(&filter_stats, &args.output, &args.n_threads, tables::fisher)
-                .unwrap();
+                .unwrap());
         } else if args.analysis == String::from("chisq_test") {
-            output = file_sync
+            output = format!("FILE CREATED: {}", file_sync
                 .read_analyse_write(&filter_stats, &args.output, &args.n_threads, tables::chisq)
-                .unwrap();
-        } else if args.analysis == String::from("pearson_corr") {
+                .unwrap());
+        } else if args.analysis == "pearson_corr" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
-            output = file_sync_phen
+            output = format!("FILE CREATED: {}", file_sync_phen
                 .read_analyse_write(
                     &filter_stats,
                     &args.output,
                     &args.n_threads,
                     gwas::correlation,
                 )
-                .unwrap();
-        } else if args.analysis == String::from("ols_iter") {
+                .unwrap());
+        } else if args.analysis == "ols_iter" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
-            output = file_sync_phen
+            output = format!("FILE CREATED: {}", file_sync_phen
                 .read_analyse_write(
                     &filter_stats,
                     &args.output,
                     &args.n_threads,
                     gwas::ols_iterate,
                 )
-                .unwrap();
-            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
-
-            if args.generate_plots {
-                python_scripts.push(("plot_manhattan.py", vec![]));
-                python_scripts.push(("plot_qq.py", vec![]));
-            }
-            if let Some(gff_filename) = &args.fname_gff {
-                let window_size_str = args.gff_window_size.to_string();
-                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
-            }
-            if args.output_sig_snps_only {
-                python_scripts.push(("remove_insig_snps.py", vec![]));
-            }
-            if !python_scripts.is_empty() {
-                output = base::run_python_and_append(&output.clone(), &python_scripts);
-            }
-        } else if args.analysis == String::from("ols_iter_with_kinship") {
+                .unwrap());
+        } else if args.analysis == "ols_iter_with_kinship" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
             let mut genotypes_and_phenotypes = file_sync_phen
                 .into_genotypes_and_phenotypes(&filter_stats, args.keep_p_minus_1, &args.n_threads)
                 .unwrap();
-            output = ols_with_covariate(
+            output = format!("FILE CREATED: {}", ols_with_covariate(
                 &mut genotypes_and_phenotypes,
                 args.xxt_eigen_variance_explained,
                 &args.fname.clone(),
                 &args.output,
             )
-            .unwrap();
-            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
-
-            if args.generate_plots {
-                python_scripts.push(("plot_manhattan.py", vec![]));
-                python_scripts.push(("plot_qq.py", vec![]));
-            }
-            if let Some(gff_filename) = &args.fname_gff {
-                let window_size_str = args.gff_window_size.to_string();
-                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
-            }
-            if args.output_sig_snps_only {
-                python_scripts.push(("remove_insig_snps.py", vec![]));
-            }
-            if !python_scripts.is_empty() {
-                output = base::run_python_and_append(&output.clone(), &python_scripts);
-            }
-        } else if args.analysis == String::from("mle_iter") {
+            .unwrap());
+        } else if args.analysis == "mle_iter" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
-            output = file_sync_phen
+            output = format!("FILE CREATED: {}", file_sync_phen
                 .read_analyse_write(
                     &filter_stats,
                     &args.output,
                     &args.n_threads,
                     gwas::mle_iterate,
                 )
-                .unwrap();
-            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
-
-            if args.generate_plots {
-                python_scripts.push(("plot_manhattan.py", vec![]));
-                python_scripts.push(("plot_qq.py", vec![]));
-            }
-            if let Some(gff_filename) = &args.fname_gff {
-                let window_size_str = args.gff_window_size.to_string();
-                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
-            }
-            if args.output_sig_snps_only {
-                python_scripts.push(("remove_insig_snps.py", vec![]));
-            }
-            if !python_scripts.is_empty() {
-                output = base::run_python_and_append(&output.clone(), &python_scripts);
-            }
-        } else if args.analysis == String::from("mle_iter_with_kinship") {
+                .unwrap());
+        } else if args.analysis == "mle_iter_with_kinship" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
             let genotypes_and_phenotypes = file_sync_phen
                 .into_genotypes_and_phenotypes(&filter_stats, args.keep_p_minus_1, &args.n_threads)
                 .unwrap();
-            output = mle_with_covariate(
+            output = format!("FILE CREATED: {}", mle_with_covariate(
                 &genotypes_and_phenotypes,
                 args.xxt_eigen_variance_explained,
                 &args.fname.clone(),
                 &args.output,
             )
-            .unwrap();
-            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
-
-            if args.generate_plots {
-                python_scripts.push(("plot_manhattan.py", vec![]));
-                python_scripts.push(("plot_qq.py", vec![]));
-            }
-            if let Some(gff_filename) = &args.fname_gff {
-                let window_size_str = args.gff_window_size.to_string();
-                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
-            }
-            if args.output_sig_snps_only {
-                python_scripts.push(("remove_insig_snps.py", vec![]));
-            }
-            if !python_scripts.is_empty() {
-                output = base::run_python_and_append(&output.clone(), &python_scripts);
-            }
-        } else if args.analysis == String::from("gwalpha") {
+            .unwrap());
+        } else if args.analysis == "gwalpha" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
             if args.gwalpha_method == "LS".to_owned() {
-                output = file_sync_phen
+                output = format!("FILE CREATED: {}", file_sync_phen
                     .read_analyse_write(
                         &filter_stats,
                         &args.output,
                         &args.n_threads,
                         gwas::gwalpha_ls,
                     )
-                    .unwrap()
+                    .unwrap())
             } else {
                 // Defaut is ML, i.e. maximum likelihood estimation
-                output = file_sync_phen
+                output = format!("FILE CREATED: {}", file_sync_phen
                     .read_analyse_write(
                         &filter_stats,
                         &args.output,
                         &args.n_threads,
                         gwas::gwalpha_ml,
                     )
-                    .unwrap()
+                    .unwrap())
             }
-        } else if args.analysis == String::from("sync2csv") {
+        } else if args.analysis == "sync2csv" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
-            output = file_sync_phen
+            output = format!("FILE CREATED: {}", file_sync_phen
                 .write_csv(
                     &filter_stats,
                     args.keep_p_minus_1,
                     &args.output,
                     &args.n_threads,
                 )
-                .unwrap();
-        // } else if args.analysis == String::from("impute") {
+                .unwrap());
+        // } else if args.analysis == "impute" {
         //     let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
         //     output = if &args.imputation_method == &"mean".to_owned() {
         //         impute_mean(
@@ -436,7 +372,7 @@ fn main() {
         //         )
         //         .unwrap()
         //     }
-        } else if args.analysis == String::from("genomic_prediction_cross_validation") {
+        } else if args.analysis == "genomic_prediction_cross_validation" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
             let genotypes_and_phenotypes = file_sync_phen
                 .into_genotypes_and_phenotypes(&filter_stats, args.keep_p_minus_1, &args.n_threads)
@@ -466,7 +402,7 @@ fn main() {
             let message = "Predictors for each model are here:\n-".to_owned()
                 + &predictor_files.join("\n-")[..];
             println!("{:?}", message);
-        } else if args.analysis == String::from("fst") {
+        } else if args.analysis == "fst" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
             let genotypes_and_phenotypes = file_sync_phen
                 .into_genotypes_and_phenotypes(&filter_stats, args.keep_p_minus_1, &args.n_threads)
@@ -480,13 +416,13 @@ fn main() {
                 &args.output,
             )
             .unwrap();
-            output = genome_wide + " and " + &per_window[..];
-        } else if args.analysis == String::from("heterozygosity") {
+            output = format!("FILE CREATED: {}", genome_wide + " and " + &per_window[..]);
+        } else if args.analysis == "heterozygosity" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
             let genotypes_and_phenotypes = file_sync_phen
                 .into_genotypes_and_phenotypes(&filter_stats, false, &args.n_threads)
                 .unwrap(); // we need all alleles in each locus
-            output = pi(
+            output = format!("FILE CREATED: {}", pi(
                 &genotypes_and_phenotypes,
                 &args.window_size_bp,
                 &args.window_slide_size_bp,
@@ -494,28 +430,13 @@ fn main() {
                 &args.fname,
                 &args.output,
             )
-            .unwrap();
-        } else if args.analysis == String::from("watterson_estimator") {
+            .unwrap());
+        } else if args.analysis == "watterson_estimator" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
             let genotypes_and_phenotypes = file_sync_phen
                 .into_genotypes_and_phenotypes(&filter_stats, false, &args.n_threads)
                 .unwrap(); // we need all alleles in each locus
-            output = watterson_estimator(
-                &genotypes_and_phenotypes,
-                &file_sync_phen.pool_sizes,
-                &args.window_size_bp,
-                &args.window_slide_size_bp,
-                &args.min_loci_per_window,
-                &args.fname,
-                &args.output,
-            )
-            .unwrap();
-        } else if args.analysis == String::from("tajima_d") {
-            let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
-            let genotypes_and_phenotypes = file_sync_phen
-                .into_genotypes_and_phenotypes(&filter_stats, false, &args.n_threads)
-                .unwrap(); // we need all alleles in each locus
-            output = tajima_d(
+            output = format!("FILE CREATED: {}", watterson_estimator(
                 &genotypes_and_phenotypes,
                 &file_sync_phen.pool_sizes,
                 &args.window_size_bp,
@@ -524,13 +445,28 @@ fn main() {
                 &args.fname,
                 &args.output,
             )
-            .unwrap();
-        } else if args.analysis == String::from("gudmc") {
+            .unwrap());
+        } else if args.analysis == "tajima_d" {
             let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
             let genotypes_and_phenotypes = file_sync_phen
                 .into_genotypes_and_phenotypes(&filter_stats, false, &args.n_threads)
                 .unwrap(); // we need all alleles in each locus
-            output = gudmc(
+            output = format!("FILE CREATED: {}", tajima_d(
+                &genotypes_and_phenotypes,
+                &file_sync_phen.pool_sizes,
+                &args.window_size_bp,
+                &args.window_slide_size_bp,
+                &args.min_loci_per_window,
+                &args.fname,
+                &args.output,
+            )
+            .unwrap());
+        } else if args.analysis == "gudmc" {
+            let file_sync_phen = *(file_sync, file_phen).lparse().unwrap();
+            let genotypes_and_phenotypes = file_sync_phen
+                .into_genotypes_and_phenotypes(&filter_stats, false, &args.n_threads)
+                .unwrap(); // we need all alleles in each locus
+            output = format!("FILE CREATED: {}", gudmc(
                 &genotypes_and_phenotypes,
                 &file_sync_phen.pool_sizes,
                 &args.sigma_threshold,
@@ -541,10 +477,36 @@ fn main() {
                 &args.fname,
                 &args.output,
             )
-            .unwrap();
+            .unwrap());
         } else {
              panic!("Invalid analysis utility - please select another utility");
         }
+    }
+
+    // execute python pipeline for gwas
+    match args.analysis.as_str() {
+        "ols_iter"
+        | "ols_iter_with_kinship"
+        | "mle_iter"
+        | "mle_iter_with_kinship" => {
+            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
+
+            if args.generate_plots {
+                python_scripts.push(("plot_manhattan.py", vec![]));
+                python_scripts.push(("plot_qq.py", vec![]));
+            }
+            if let Some(gff_filename) = &args.fname_gff {
+                let window_size_str = args.gff_window_size.to_string();
+                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
+            }
+            if args.output_sig_snps_only {
+                python_scripts.push(("remove_insig_snps.py", vec![]));
+            }
+            if !python_scripts.is_empty() {
+                output = base::run_python_and_append(&output.clone(), &python_scripts);
+            }
+        }
+        _ => {}
     }
     println!("{}", output);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,12 @@ struct Args {
     /// Input phenotype file: csv or tsv or any delimited file
     #[clap(short, long)]
     phen_fname: String,
+    /// GFF file for extracting potential causative genes from GWAS
+    #[clap(long)]
+    fname_gff: Option<String>,
+    /// GFF window size (look for genes within gff_window_size of a significant SNP)
+    #[clap(long, default_value_t = 500)]
+    gff_window_size: u64,
     /// Delimiter of the input phenotype file: comma, tab, etc...
     #[clap(long, default_value = ",")]
     phen_delim: String,
@@ -270,10 +276,19 @@ fn main() {
                     gwas::ols_iterate,
                 )
                 .unwrap();
-            let python_scripts: Vec<&str> = [
-                args.generate_plots.then_some(["plot_manhattan.py", "plot_qq.py"].as_slice()).unwrap_or(&[]),
-                args.output_sig_snps_only.then_some(["remove_insig_snps.py"].as_slice()).unwrap_or(&[])
-            ].concat();
+            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
+
+            if args.generate_plots {
+                python_scripts.push(("plot_manhattan.py", vec![]));
+                python_scripts.push(("plot_qq.py", vec![]));
+            }
+            if let Some(gff_filename) = &args.fname_gff {
+                let window_size_str = args.gff_window_size.to_string();
+                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
+            }
+            if args.output_sig_snps_only {
+                python_scripts.push(("remove_insig_snps.py", vec![]));
+            }
             if !python_scripts.is_empty() {
                 output = base::run_python_and_append(&output.clone(), &python_scripts);
             }
@@ -289,10 +304,19 @@ fn main() {
                 &args.output,
             )
             .unwrap();
-            let python_scripts: Vec<&str> = [
-                args.generate_plots.then_some(["plot_manhattan.py", "plot_qq.py"].as_slice()).unwrap_or(&[]),
-                args.output_sig_snps_only.then_some(["remove_insig_snps.py"].as_slice()).unwrap_or(&[])
-            ].concat();
+            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
+
+            if args.generate_plots {
+                python_scripts.push(("plot_manhattan.py", vec![]));
+                python_scripts.push(("plot_qq.py", vec![]));
+            }
+            if let Some(gff_filename) = &args.fname_gff {
+                let window_size_str = args.gff_window_size.to_string();
+                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
+            }
+            if args.output_sig_snps_only {
+                python_scripts.push(("remove_insig_snps.py", vec![]));
+            }
             if !python_scripts.is_empty() {
                 output = base::run_python_and_append(&output.clone(), &python_scripts);
             }
@@ -306,10 +330,19 @@ fn main() {
                     gwas::mle_iterate,
                 )
                 .unwrap();
-            let python_scripts: Vec<&str> = [
-                args.generate_plots.then_some(["plot_manhattan.py", "plot_qq.py"].as_slice()).unwrap_or(&[]),
-                args.output_sig_snps_only.then_some(["remove_insig_snps.py"].as_slice()).unwrap_or(&[])
-            ].concat();
+            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
+
+            if args.generate_plots {
+                python_scripts.push(("plot_manhattan.py", vec![]));
+                python_scripts.push(("plot_qq.py", vec![]));
+            }
+            if let Some(gff_filename) = &args.fname_gff {
+                let window_size_str = args.gff_window_size.to_string();
+                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
+            }
+            if args.output_sig_snps_only {
+                python_scripts.push(("remove_insig_snps.py", vec![]));
+            }
             if !python_scripts.is_empty() {
                 output = base::run_python_and_append(&output.clone(), &python_scripts);
             }
@@ -325,10 +358,19 @@ fn main() {
                 &args.output,
             )
             .unwrap();
-            let python_scripts: Vec<&str> = [
-                args.generate_plots.then_some(["plot_manhattan.py", "plot_qq.py"].as_slice()).unwrap_or(&[]),
-                args.output_sig_snps_only.then_some(["remove_insig_snps.py"].as_slice()).unwrap_or(&[])
-            ].concat();
+            let mut python_scripts: Vec<(&str, Vec<String>)> = Vec::new();
+
+            if args.generate_plots {
+                python_scripts.push(("plot_manhattan.py", vec![]));
+                python_scripts.push(("plot_qq.py", vec![]));
+            }
+            if let Some(gff_filename) = &args.fname_gff {
+                let window_size_str = args.gff_window_size.to_string();
+                python_scripts.push(("extract_snps_from_gff.py", vec![gff_filename.clone(), window_size_str]));
+            }
+            if args.output_sig_snps_only {
+                python_scripts.push(("remove_insig_snps.py", vec![]));
+            }
             if !python_scripts.is_empty() {
                 output = base::run_python_and_append(&output.clone(), &python_scripts);
             }

--- a/src/python/extract_snps_from_gff.py
+++ b/src/python/extract_snps_from_gff.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import warnings
+from pathlib import Path 
+import sys
+warnings.filterwarnings("ignore")
+
+gwas_filename = sys.argv[1]
+gwas = pd.read_csv(gwas_filename, index_col=0)
+num_phenotypes = gwas['phenotype'].nunique()
+
+gwas["chromosome"] = gwas.index
+gwas = gwas[gwas["chromosome"] != "intercept"]
+
+sig_threshold = 0.05/(len(gwas)/num_phenotypes) # bonferonni correction
+
+gwas = gwas[gwas["pvalue"] < sig_threshold]
+
+gff_filename = sys.argv[2]
+gff_window_size = int(sys.argv[3])
+gff = pd.read_csv(gff_filename, sep = "\t", header=None)
+
+gff.columns = ["seqid", "source", "type", "start", "end", "score", "strand", "phase", "attributes"]
+
+gwas['key'] = 1
+gff['key'] = 1
+gwas['pos'] = gwas['pos'].astype(int)
+merged = pd.merge(gwas, gff, on='key').drop(columns='key')
+
+filtered = merged[
+    (merged['start'] <= merged['pos'] + gff_window_size) & 
+    (merged['end'] >= merged['pos'] - gff_window_size)
+]
+
+gff = filtered.drop(columns='pos').drop_duplicates().reset_index(drop=True)
+
+output_path = Path(gff_filename)
+output_path = output_path.with_stem(output_path.stem + "_GWAS_SIG_SNPS")
+gwas.to_csv(output_path)
+gff.to_csv(output_path, sep="\t", header=False, index=False, quoting=3)
+
+print(output_path.name, end="")

--- a/src/python/extract_snps_from_gff.py
+++ b/src/python/extract_snps_from_gff.py
@@ -37,4 +37,4 @@ output_path = Path(gff_filename)
 output_path = output_path.with_stem(output_path.stem + "_GWAS_SIG_SNPS")
 gff.to_csv(output_path, sep="\t", header=False, index=False, quoting=3)
 
-print(output_path.name, end="")
+print("FILE CREATED: " + output_path.name, end="")

--- a/src/python/extract_snps_from_gff.py
+++ b/src/python/extract_snps_from_gff.py
@@ -35,7 +35,6 @@ gff = filtered.drop(columns='pos').drop_duplicates().reset_index(drop=True)
 
 output_path = Path(gff_filename)
 output_path = output_path.with_stem(output_path.stem + "_GWAS_SIG_SNPS")
-gwas.to_csv(output_path)
 gff.to_csv(output_path, sep="\t", header=False, index=False, quoting=3)
 
 print(output_path.name, end="")

--- a/src/python/plot_manhattan.py
+++ b/src/python/plot_manhattan.py
@@ -54,10 +54,10 @@ for gwas_key in gwas_phenotypes:
     plt.legend(title="Chromosome", bbox_to_anchor=(1.05, 1), loc="upper left")
 
     plt.tight_layout()
-    output_path = "FILE CREATED: " + Path(filename).stem + "_" + gwas_key + "_manhattan.png"
+    output_path = Path(filename).stem + "_" + gwas_key + "_manhattan.png"
     output_paths += output_path + "\n"
     plt.tight_layout()
     plt.savefig(output_path, bbox_inches='tight', dpi=300)
 
 output_paths = output_paths[:-1]
-print(output_paths, end="")
+print("FILE CREATED: " + output_paths, end="")

--- a/src/python/plot_manhattan.py
+++ b/src/python/plot_manhattan.py
@@ -54,7 +54,7 @@ for gwas_key in gwas_phenotypes:
     plt.legend(title="Chromosome", bbox_to_anchor=(1.05, 1), loc="upper left")
 
     plt.tight_layout()
-    output_path = Path(filename).stem + "_" + gwas_key + "_manhattan.png"
+    output_path = "FILE CREATED: " + Path(filename).stem + "_" + gwas_key + "_manhattan.png"
     output_paths += output_path + "\n"
     plt.tight_layout()
     plt.savefig(output_path, bbox_inches='tight', dpi=300)

--- a/src/python/plot_qq.py
+++ b/src/python/plot_qq.py
@@ -38,7 +38,7 @@ for gwas_key in gwas_phenotypes:
              bbox=dict(boxstyle="round", facecolor="white", alpha=0.6))
     plt.grid(True)
     plt.tight_layout()
-    output_path = Path(filename).stem + "_" + gwas_key + "_qq.png"
+    output_path = "FILE CREATED: " + Path(filename).stem + "_" + gwas_key + "_qq.png"
     output_paths += output_path + "\n"
     plt.tight_layout()
     plt.savefig(output_path, dpi=300)

--- a/src/python/plot_qq.py
+++ b/src/python/plot_qq.py
@@ -38,10 +38,10 @@ for gwas_key in gwas_phenotypes:
              bbox=dict(boxstyle="round", facecolor="white", alpha=0.6))
     plt.grid(True)
     plt.tight_layout()
-    output_path = "FILE CREATED: " + Path(filename).stem + "_" + gwas_key + "_qq.png"
+    output_path = Path(filename).stem + "_" + gwas_key + "_qq.png"
     output_paths += output_path + "\n"
     plt.tight_layout()
     plt.savefig(output_path, dpi=300)
 
 output_paths = output_paths[:-1]
-print(output_paths, end="")
+print("FILE CREATED: " + output_paths, end="")

--- a/src/python/remove_insig_snps.py
+++ b/src/python/remove_insig_snps.py
@@ -19,3 +19,4 @@ gwas = gwas[gwas["pvalue"] < sig_threshold]
 
 output_path = Path(filename)
 gwas.to_csv(output_path)
+print("DONE: Insignificant SNPs removed from " + output_path.name + "", end="")

--- a/src/python/remove_insig_snps.py
+++ b/src/python/remove_insig_snps.py
@@ -4,14 +4,12 @@ from pathlib import Path
 import sys
 warnings.filterwarnings("ignore")
 
-
 filename = sys.argv[1]
 gwas = pd.read_csv(filename, index_col=0)
 num_phenotypes = gwas['phenotype'].nunique()
 
 gwas["chromosome"] = gwas.index
 gwas = gwas[gwas["chromosome"] != "intercept"]
-gwas["position"] = gwas["pos"]
 
 sig_threshold = 0.05/(len(gwas)/num_phenotypes) # bonferonni correction
 


### PR DESCRIPTION
New feature: Extract potentially significant annotations from a `.gff` file based on significant SNPs identified from the 4 GWAS tools.

2 new flags:
    1. fname_gff: Option\<String\>,
    2. gff_window_size: u64,

If a fname_gff is provided, poolgen will look for genes within gff_window_size of significant SNPs and output a new `.gff` file with only the significant annotations. (with suffix "_GWAS_SIG_SNPS").